### PR TITLE
Fix compatibility with `mdformat-doc`

### DIFF
--- a/mdformat_recover_urls/plugin.py
+++ b/mdformat_recover_urls/plugin.py
@@ -1,6 +1,7 @@
 import re
-from urllib.parse import unquote
 from typing import Mapping
+from urllib.parse import unquote
+
 from markdown_it import MarkdownIt
 from mdformat.renderer import RenderContext, RenderTreeNode
 from mdformat.renderer.typing import Render
@@ -14,17 +15,47 @@ def update_mdit(mdit: MarkdownIt) -> None:
 
 
 def _is_pct_encoded(s: str) -> bool:
+    """Check if the string contains any percent-encoded sequences."""
     return bool(_PCT.search(s))
 
 
-def _recover_urls(node: RenderTreeNode, context: RenderContext) -> str:
-    title = "".join(child.render(context) for child in (node.children or []))
-    url = node.attrs.get("href", "")
+def _unquote_url(url: str) -> str:
+    """Unquote URL if it's a relative link or a fragment."""
     if isinstance(url, str) and _MD_REL_LINK.match(url):
         url = unquote(url) if _is_pct_encoded(url) else url
+    return url
+
+
+def _recover_urls(node: RenderTreeNode, context: RenderContext) -> str:
+    """Recover percent-encoded URLs in link nodes."""
+    title = "".join(child.render(context) for child in (node.children or []))
+    url = _unquote_url(node.attrs.get("href", ""))
     return f"[{title}]({url})"
 
 
 RENDERERS: Mapping[str, Render] = {
     "link": _recover_urls,
 }
+
+
+# XXX mdformat-recover-urls and mdformat-toc plugins are not compatible. See:
+# https://github.com/hukkin/mdformat-toc/issues/19
+# https://github.com/holy-two/mdformat-recover-urls/pull/2
+# https://github.com/hukkin/mdformat/issues/312#issuecomment-1586025822
+# So we're going to monkey-patch mdformat-toc's link rendering.
+try:
+    from mdformat_toc import plugin
+
+    # Save the original function.
+    original_func = plugin._maybe_add_link_brackets
+
+    def _patched_maybe_add_link_brackets(link: str) -> str:
+        """Force unquoting of URLs slugs in mdformat-toc."""
+        return original_func(_unquote_url(link))
+
+    # Use our patched version instead of the original one.
+    plugin._maybe_add_link_brackets = _patched_maybe_add_link_brackets
+
+# Do nothing if mdformat-toc is not installed.
+except ImportError:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["mdformat>=0.7.17", "markdown-it-py>=2.2.0"]
 urls = { github = "https://github.com/holy-two/mdformat-recover-urls" }
 
 [dependency-groups]
-dev = ["pytest>=8.3.5"]
+dev = ["pytest>=8.3.5", "mdformat-toc>=0.3.0"]
 
 [project.entry-points."mdformat.parser_extension"]
 recover-urls = "mdformat_recover_urls.plugin"

--- a/test.py
+++ b/test.py
@@ -1,19 +1,95 @@
+from textwrap import dedent
+
 import mdformat
 
 
 def test_mdformat_recover_urls():
-    md = """# TEST
+    original = dedent("""\
+        # TEST
 
-- [title](./中文.md)
-- [title](#中文)
+        - [Relative path](./中文.md)
+        - [URL fragment](#中文)
+        - [概述](#%E6%A6%82%E8%BF%B0)
 
-## 中文
-"""
+        ## 中文
 
-    formatted = mdformat.text(md, extensions=["recover-urls"])
+        ## 概述
+        """)
 
-    print("原文:", repr(md))
+    expected = dedent("""\
+        # TEST
+
+        - [Relative path](./中文.md)
+        - [URL fragment](#中文)
+        - [概述](#概述)
+
+        ## 中文
+
+        ## 概述
+        """)
+
+    formatted = mdformat.text(original, extensions=["recover-urls"])
+
+    print("原文:", repr(original))
     print("格式化:", repr(formatted))
 
-    assert "./中文.md" in formatted
-    assert "#中文" in formatted
+    assert formatted == expected
+
+
+def test_mdformat_toc_no_conflicts():
+    original = dedent("""\
+        ## Contents
+
+        <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+        - [Contents](#contents)
+        - [授权](#%E6%8E%88%E6%9D%83)
+          - [RBAC 框架](#rbac-%E6%A1%86%E6%9E%B6)
+          - [ABAC 框架](#abac-框架)
+          - [Macaroons](#macaroons)
+        - [OAuth2 & OpenID](#oauth2--openid)
+
+        <!-- mdformat-toc end -->
+
+        ## 策略模型
+
+        ### RBAC 框架
+
+        ### ABAC 框架
+
+        ### Macaroons
+
+        ## OAuth2 & OpenID
+        """)
+
+    expected = dedent("""\
+        ## Contents
+
+        <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
+
+        - [Contents](#contents)
+        - [策略模型](#策略模型)
+          - [RBAC 框架](#rbac-框架)
+          - [ABAC 框架](#abac-框架)
+          - [Macaroons](#macaroons)
+        - [OAuth2 & OpenID](#oauth2--openid)
+
+        <!-- mdformat-toc end -->
+
+        ## 策略模型
+
+        ### RBAC 框架
+
+        ### ABAC 框架
+
+        ### Macaroons
+
+        ## OAuth2 & OpenID
+        """)
+
+    formatted = mdformat.text(original, extensions=["recover-urls", "toc"])
+
+    print("原文:", repr(original))
+    print("格式化:", repr(formatted))
+
+    assert formatted == expected

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -125,6 +125,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mdformat-toc" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
@@ -136,7 +137,23 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+dev = [
+    { name = "mdformat-toc", specifier = ">=0.3.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+]
+
+[[package]]
+name = "mdformat-toc"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat", version = "0.7.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "mdformat", version = "0.7.22", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/5c/c3dfdf66aba3468ef031be23fe25083f2d5410de86fd4f86f76571e2e94d/mdformat-toc-0.3.0.tar.gz", hash = "sha256:e8735f7517068f274b58b83407491b75445dc938473a3d5fa6467c0db0142daa", size = 9847, upload-time = "2021-04-12T20:52:14.607Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/1e/dabc477b3e564c358bf84afa6f8e4995a8440c384df8407c360ebb8f659e/mdformat_toc-0.3.0-py3-none-any.whl", hash = "sha256:49d1f47d563f47405f3c165c6a4c30e8404a39f56ae254a27c2a90dd7eae1849", size = 9752, upload-time = "2021-04-12T20:52:15.58Z" },
+]
 
 [[package]]
 name = "mdurl"


### PR DESCRIPTION
I just stumble upon an incompatibility between `mdformat-recover-urls` and [`mdformat-toc`](https://github.com/hukkin/mdformat-toc).

I detailed the issue at: https://github.com/hukkin/mdformat-toc/issues/19

So here is a PR that is dynamically patching `mdformat-toc` to fix the rendering of links it produces.

Refs:
- https://github.com/hukkin/mdformat-toc/issues/19
- https://github.com/hukkin/mdformat/issues/312#issuecomment-1586025822